### PR TITLE
feat: refine category tags and color picker

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <rect x="2" y="7" width="20" height="10" rx="2" ry="2" />
-  <path d="M2 7V5a2 2 0 0 1 2-2h16" />
-  <circle cx="16" cy="12" r="1" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="2" y="7" width="20" height="11" rx="2" ry="2" fill="hsl(174, 44%, 51%)"/>
+  <path d="M2 7V5a2 2 0 0 1 2-2h16v2H4a2 2 0 0 0-2 2z" fill="hsl(174, 44%, 45%)"/>
+  <circle cx="17" cy="12.5" r="2" fill="white"/>
 </svg>

--- a/src/components/finance/CategoryManagementDialog.tsx
+++ b/src/components/finance/CategoryManagementDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, type ChangeEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -38,6 +38,12 @@ const CategoryManagementDialog = ({
     type: 'expense' as 'income' | 'expense'
   });
   const { toast } = useToast();
+  const customColorRef = useRef<HTMLInputElement>(null);
+  const editColorRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  const handleCustomColorChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setNewCategory(prev => ({ ...prev, color: e.target.value }));
+  };
 
   const handleAddCategory = () => {
     if (!newCategory.name.trim()) {
@@ -162,6 +168,19 @@ const CategoryManagementDialog = ({
                     onClick={() => setNewCategory(prev => ({ ...prev, color }))}
                   />
                 ))}
+                <button
+                  type="button"
+                  className="w-8 h-8 rounded-full border-2 border-muted flex items-center justify-center text-muted-foreground"
+                  onClick={() => customColorRef.current?.click()}
+                >
+                  <Plus className="w-4 h-4" />
+                </button>
+                <input
+                  type="color"
+                  ref={customColorRef}
+                  className="sr-only"
+                  onChange={handleCustomColorChange}
+                />
               </div>
             </div>
 
@@ -218,9 +237,15 @@ const CategoryManagementDialog = ({
                         </Button>
                       </div>
                       
-                      <Select 
-                        value={category.color} 
-                        onValueChange={(color) => handleUpdateCategory(category.id, 'color', color)}
+                      <Select
+                        value={category.color}
+                        onValueChange={(color) => {
+                          if (color === 'custom') {
+                            editColorRefs.current[category.id]?.click();
+                          } else {
+                            handleUpdateCategory(category.id, 'color', color);
+                          }
+                        }}
                       >
                         <SelectTrigger className="w-24">
                           <SelectValue />
@@ -229,15 +254,29 @@ const CategoryManagementDialog = ({
                           {predefinedColors.map((color) => (
                             <SelectItem key={color} value={color}>
                               <div className="flex items-center gap-2">
-                                <div 
-                                  className="w-4 h-4 rounded-full" 
+                                <div
+                                  className="w-4 h-4 rounded-full"
                                   style={{ backgroundColor: color }}
                                 />
                               </div>
                             </SelectItem>
                           ))}
+                          <SelectItem value="custom">
+                            <div className="flex items-center gap-2">
+                              <div className="w-4 h-4 rounded-full border flex items-center justify-center">
+                                <Plus className="w-3 h-3" />
+                              </div>
+                              <span>Personalizar</span>
+                            </div>
+                          </SelectItem>
                         </SelectContent>
                       </Select>
+                      <input
+                        type="color"
+                        ref={(el) => (editColorRefs.current[category.id] = el)}
+                        className="sr-only"
+                        onChange={(e) => handleUpdateCategory(category.id, 'color', e.target.value)}
+                      />
                     </div>
                   ))}
                 </div>
@@ -286,9 +325,15 @@ const CategoryManagementDialog = ({
                         </Button>
                       </div>
                       
-                      <Select 
-                        value={category.color} 
-                        onValueChange={(color) => handleUpdateCategory(category.id, 'color', color)}
+                      <Select
+                        value={category.color}
+                        onValueChange={(color) => {
+                          if (color === 'custom') {
+                            editColorRefs.current[category.id]?.click();
+                          } else {
+                            handleUpdateCategory(category.id, 'color', color);
+                          }
+                        }}
                       >
                         <SelectTrigger className="w-24">
                           <SelectValue />
@@ -297,15 +342,29 @@ const CategoryManagementDialog = ({
                           {predefinedColors.map((color) => (
                             <SelectItem key={color} value={color}>
                               <div className="flex items-center gap-2">
-                                <div 
-                                  className="w-4 h-4 rounded-full" 
+                                <div
+                                  className="w-4 h-4 rounded-full"
                                   style={{ backgroundColor: color }}
                                 />
                               </div>
                             </SelectItem>
                           ))}
+                          <SelectItem value="custom">
+                            <div className="flex items-center gap-2">
+                              <div className="w-4 h-4 rounded-full border flex items-center justify-center">
+                                <Plus className="w-3 h-3" />
+                              </div>
+                              <span>Personalizar</span>
+                            </div>
+                          </SelectItem>
                         </SelectContent>
                       </Select>
+                      <input
+                        type="color"
+                        ref={(el) => (editColorRefs.current[category.id] = el)}
+                        className="sr-only"
+                        onChange={(e) => handleUpdateCategory(category.id, 'color', e.target.value)}
+                      />
                     </div>
                   ))}
                 </div>

--- a/src/components/finance/TransactionsList.tsx
+++ b/src/components/finance/TransactionsList.tsx
@@ -342,11 +342,13 @@ const TransactionsList = ({
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-1">
                         <span className="font-medium">{transaction.description}</span>
-                        <Badge 
-                          variant={transaction.type === 'income' ? 'default' : 'secondary'}
+                        <Badge
+                          variant="outline"
                           className={cn(
                             "cursor-pointer transition-colors",
-                            transaction.type === 'income' ? 'bg-income text-white' : 'bg-expense text-white'
+                            transaction.type === 'income'
+                              ? 'text-income border-income/50 bg-income/10 hover:bg-income/20'
+                              : 'text-expense border-expense/50 bg-expense/10 hover:bg-expense/20'
                           )}
                           onClick={() => handleCategoryFilter(transaction.categoryId)}
                         >

--- a/src/components/finance/UnifiedCharts.tsx
+++ b/src/components/finance/UnifiedCharts.tsx
@@ -23,6 +23,7 @@ import {
   Tooltip,
   LabelList,
   ComposedChart,
+  type LabelProps,
 } from "recharts";
 
 interface UnifiedChartsProps {
@@ -34,7 +35,7 @@ interface UnifiedChartsProps {
   currentDate: Date | { year: number; month: number };
 }
 
-const UnifiedCharts = ({ 
+const UnifiedCharts = ({
   transactions, 
   categories, 
   totalIncome, 
@@ -44,6 +45,8 @@ const UnifiedCharts = ({
 }: UnifiedChartsProps) => {
   // Convert currentDate to Date object if needed
   const dateObj = currentDate instanceof Date ? currentDate : new Date(currentDate.year, currentDate.month - 1);
+
+  const valuesVisible = true;
 
   // Income vs Expense chart data
   const incomeExpenseData = [
@@ -201,6 +204,7 @@ const UnifiedCharts = ({
                       <Tooltip
                         formatter={(value: number) => [formatCurrency(value), '']}
                         labelFormatter={(label) => label}
+                        wrapperStyle={{ filter: valuesVisible ? 'none' : 'blur(4px)' }}
                         contentStyle={{
                           backgroundColor: 'hsl(var(--card))',
                           border: '1px solid hsl(var(--border))',
@@ -222,9 +226,23 @@ const UnifiedCharts = ({
                         <LabelList
                           dataKey="value"
                           position="top"
-                          formatter={(value: number) => formatCurrency(value)}
-                          fill="hsl(var(--foreground))"
-                          fontSize={12}
+                          content={(props: LabelProps) => {
+                            const { value, viewBox } = props;
+                            if (!viewBox) return null;
+                            const { x, y, width } = viewBox;
+                            return (
+                              <text
+                                x={x + width / 2}
+                                y={y - 4}
+                                textAnchor="middle"
+                                fill="hsl(var(--foreground))"
+                                fontSize={12}
+                                className={!valuesVisible ? 'blur-sm select-none' : ''}
+                              >
+                                {formatCurrency(Number(value))}
+                              </text>
+                            );
+                          }}
                         />
                       </Bar>
                     </RechartsBarChart>
@@ -272,6 +290,7 @@ const UnifiedCharts = ({
                         <Tooltip
                           formatter={(value: number) => [formatCurrency(value), '']}
                           labelFormatter={(label) => label}
+                          wrapperStyle={{ filter: valuesVisible ? 'none' : 'blur(4px)' }}
                           contentStyle={{
                             backgroundColor: 'hsl(var(--card))',
                             border: '1px solid hsl(var(--border))',
@@ -283,7 +302,7 @@ const UnifiedCharts = ({
                     </ResponsiveContainer>
                     <div className="absolute inset-0 flex flex-col items-center justify-center text-xs">
                       <span className="text-muted-foreground">Total</span>
-                      <span className="font-medium">{formatCurrency(totalExpense)}</span>
+                      <span className={`font-medium ${!valuesVisible ? 'blur-md select-none' : ''}`}>{formatCurrency(totalExpense)}</span>
                     </div>
                   </div>
                   
@@ -298,7 +317,7 @@ const UnifiedCharts = ({
                           />
                           <span className="truncate">{category.name}</span>
                         </div>
-                        <div className="flex gap-2 text-muted-foreground">
+                        <div className={`flex gap-2 text-muted-foreground ${!valuesVisible ? 'blur-sm select-none' : ''}`}>
                           <span>{formatCurrency(category.value)}</span>
                           <span>({formatPercentage(category.value, totalExpense)})</span>
                         </div>
@@ -335,10 +354,10 @@ const UnifiedCharts = ({
                 <div className="absolute top-2 right-2 z-10">
                   <ChartInfoButton chartType="projection" />
                 </div>
-                <div className="text-sm text-muted-foreground mb-4 space-y-1">
-                <p>Média diária: {formatCurrency(dailyAverage)}</p>
-                <p>Projeção mês: {formatCurrency(projectedTotal)}</p>
-              </div>
+                <div className={`text-sm text-muted-foreground mb-4 space-y-1 ${!valuesVisible ? 'blur-sm select-none' : ''}`}>
+                  <p>Média diária: {formatCurrency(dailyAverage)}</p>
+                  <p>Projeção mês: {formatCurrency(projectedTotal)}</p>
+                </div>
               <div className="h-[240px] w-full">
                 <ResponsiveContainer width="100%" height="100%">
                   <ComposedChart data={dailyData} margin={{ top: 10, right: 10, left: 10, bottom: 10 }}>
@@ -362,6 +381,7 @@ const UnifiedCharts = ({
                     />
                     <Tooltip
                       formatter={(value: number, name: string) => [formatCurrency(Number(value)), name]}
+                      wrapperStyle={{ filter: valuesVisible ? 'none' : 'blur(4px)' }}
                       contentStyle={{
                         backgroundColor: 'hsl(var(--card))',
                         border: '1px solid hsl(var(--border))',
@@ -425,11 +445,12 @@ const UnifiedCharts = ({
                       tickFormatter={(value) => `${(value / 1000).toFixed(0)}k`}
                       width={35}
                     />
-                    <Tooltip 
+                    <Tooltip
                       formatter={(value: number, name: string) => [formatCurrency(value), name]}
                       labelFormatter={(label) => label}
-                      contentStyle={{ 
-                        backgroundColor: 'hsl(var(--card))', 
+                      wrapperStyle={{ filter: valuesVisible ? 'none' : 'blur(4px)' }}
+                      contentStyle={{
+                        backgroundColor: 'hsl(var(--card))',
                         border: '1px solid hsl(var(--border))',
                         borderRadius: '6px',
                         fontSize: '12px'

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/useFinanceData.ts
+++ b/src/hooks/useFinanceData.ts
@@ -185,7 +185,7 @@ export const useFinanceData = () => {
   };
 
   const updateTransaction = async (id: string, updates: Partial<Transaction>) => {
-    const updateData: any = {};
+    const updateData: Record<string, unknown> = {};
     if (updates.description) updateData.description = updates.description;
     if (updates.amount) updateData.amount = updates.amount;
     if (updates.type) updateData.type = updates.type;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -115,5 +116,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- soften transaction category tags with subtle borders and opacity
- allow custom category colors via color picker in management dialog
- update wallet favicon for better visibility

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02b3bba78832ab341757ae5dd0b9d