### PR TITLE
feat: show category percentage in distribution tooltip

### DIFF
--- a/src/components/finance/UnifiedCharts.tsx
+++ b/src/components/finance/UnifiedCharts.tsx
@@ -269,6 +269,7 @@ const UnifiedCharts = ({
                       <PieChart>
                         <Pie
                           data={expensesByCategory}
+                          key={expensesByCategory.map(c => c.name).join('-')}
                           cx="50%"
                           cy="50%"
                           innerRadius={50}
@@ -278,9 +279,9 @@ const UnifiedCharts = ({
                           dataKey="value"
                           labelLine={false}
                         >
-                          {expensesByCategory.map((entry, index) => (
+                          {expensesByCategory.map((entry) => (
                             <Cell
-                              key={`cell-${index}`}
+                              key={`cell-${entry.name}`}
                               fill={entry.fill}
                               stroke="hsl(var(--background))"
                               strokeWidth={2}
@@ -288,14 +289,16 @@ const UnifiedCharts = ({
                           ))}
                         </Pie>
                         <Tooltip
-                          formatter={(value: number) => [formatCurrency(value), '']}
-                          labelFormatter={(label) => label}
+                          formatter={(value: number, _name, props) => [
+                            formatPercentage(Number(value), totalExpense),
+                            props?.payload?.name,
+                          ]}
                           wrapperStyle={{ filter: valuesVisible ? 'none' : 'blur(4px)' }}
                           contentStyle={{
                             backgroundColor: 'hsl(var(--card))',
                             border: '1px solid hsl(var(--border))',
                             borderRadius: '6px',
-                            fontSize: '12px'
+                            fontSize: '12px',
                           }}
                         />
                       </PieChart>
@@ -308,10 +311,10 @@ const UnifiedCharts = ({
                   
                   {/* Legend */}
                   <div className="grid grid-cols-1 gap-1 max-h-20 overflow-y-auto">
-                    {expensesByCategory.slice(0, 5).map((category, index) => (
-                      <div key={index} className="flex items-center justify-between text-xs">
+                    {expensesByCategory.map((category) => (
+                      <div key={category.name} className="flex items-center justify-between text-xs">
                         <div className="flex items-center gap-2">
-                          <div 
+                          <div
                             className="w-2 h-2 rounded-full"
                             style={{ backgroundColor: category.fill }}
                           />


### PR DESCRIPTION
## Summary
- ensure new expenses appear in pie chart
- show all expense categories in distribution legend
- display category name and percentage on hover

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a207499958832aada089c6b9f86ee9