### PR TITLE
Fix pie chart tooltip overlap and improve mobile transaction layout

### DIFF
--- a/src/components/finance/FinancialSummary.tsx
+++ b/src/components/finance/FinancialSummary.tsx
@@ -1,52 +1,20 @@
-import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { TrendingUp, TrendingDown, DollarSign, Eye, EyeOff } from "lucide-react";
+import { TrendingUp, TrendingDown, DollarSign } from "lucide-react";
 import { MonthlyData } from "@/types/finance";
 import { formatCurrency } from "@/utils/currency";
 
 interface FinancialSummaryProps {
   monthlyData: MonthlyData;
+  valuesVisible: boolean;
 }
 
-const FinancialSummary = ({ monthlyData }: FinancialSummaryProps) => {
+const FinancialSummary = ({ monthlyData, valuesVisible }: FinancialSummaryProps) => {
   const { totalIncome, totalExpense, balance } = monthlyData;
-  const [valuesVisible, setValuesVisible] = useState(false);
   
   const spentPercentage = totalIncome > 0 ? (totalExpense / totalIncome) * 100 : 0;
-  const savingsPercentage = totalIncome > 0 ? (balance / totalIncome) * 100 : 0;
-
-  // Auto-hide values after 5 minutes
-  useEffect(() => {
-    if (valuesVisible) {
-      const timer = setTimeout(() => {
-        setValuesVisible(false);
-      }, 5 * 60 * 1000); // 5 minutes
-
-      return () => clearTimeout(timer);
-    }
-  }, [valuesVisible]);
-
-  const toggleValuesVisibility = () => {
-    setValuesVisible(!valuesVisible);
-  };
-
 
   return (
     <div className="space-y-4">
-      {/* Toggle Button */}
-      <div className="flex justify-end">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={toggleValuesVisibility}
-          className="gap-2"
-        >
-          {valuesVisible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-          {valuesVisible ? 'Ocultar valores' : 'Mostrar valores'}
-        </Button>
-      </div>
-
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
         {/* Total Income */}
         <Card>

--- a/src/components/finance/TransactionsList.tsx
+++ b/src/components/finance/TransactionsList.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { CalendarIcon, Edit2, Trash2, X, Plus, Minus, ArrowUpDown, Check, TrendingUp, TrendingDown, Eye, EyeOff, Settings } from "lucide-react";
+import { CalendarIcon, Edit2, Trash2, X, Plus, Minus, ArrowUpDown, Check, TrendingUp, TrendingDown, Eye, EyeOff } from "lucide-react";
 import { format, parseISO } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { cn } from "@/lib/utils";
@@ -176,9 +176,9 @@ const TransactionsList = ({
   return (
     <Card className="h-full flex flex-col">
       <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle>Transações do Mês</CardTitle>
-          <div className="flex items-center gap-2">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+          <div className="flex items-center justify-between">
+            <CardTitle>Transações do Mês</CardTitle>
             <Button
               variant="outline"
               size="sm"
@@ -187,19 +187,22 @@ const TransactionsList = ({
             >
               {valuesVisible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
             </Button>
-            <Select value={sortOrder} onValueChange={(value) => setSortOrder(value as 'newest' | 'oldest' | 'highest' | 'lowest')}>
-              <SelectTrigger className="w-[180px] h-8">
-                <ArrowUpDown className="w-4 h-4 mr-2" />
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="newest">Mais recentes</SelectItem>
-                <SelectItem value="oldest">Mais antigos</SelectItem>
-                <SelectItem value="highest">Maior valor</SelectItem>
-                <SelectItem value="lowest">Menor valor</SelectItem>
-              </SelectContent>
-            </Select>
           </div>
+          <Select
+            value={sortOrder}
+            onValueChange={(value) => setSortOrder(value as 'newest' | 'oldest' | 'highest' | 'lowest')}
+          >
+            <SelectTrigger className="w-full sm:w-[180px] h-8">
+              <ArrowUpDown className="w-4 h-4 mr-2" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="newest">Mais recentes</SelectItem>
+              <SelectItem value="oldest">Mais antigos</SelectItem>
+              <SelectItem value="highest">Maior valor</SelectItem>
+              <SelectItem value="lowest">Menor valor</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
       </CardHeader>
 
@@ -332,10 +335,10 @@ const TransactionsList = ({
               {visibleTransactions.map((transaction) => (
                 <div
                   key={transaction.id}
-                  className="flex items-center justify-between p-4 border rounded-lg hover:bg-muted/50 transition-colors"
+                  className="p-4 border rounded-lg hover:bg-muted/50 transition-colors flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
                 >
-                  <div className="flex items-center gap-3 flex-1">
-                    <div 
+                  <div className="flex items-center gap-3 flex-1 w-full">
+                    <div
                       className="w-3 h-3 rounded-full"
                       style={{ backgroundColor: getCategoryColor(transaction.categoryId) }}
                     />
@@ -344,13 +347,9 @@ const TransactionsList = ({
                         <span className="font-medium">{transaction.description}</span>
                         <Badge
                           variant="outline"
-                          className={cn(
-                            "cursor-pointer transition-colors",
-                            transaction.type === 'income'
-                              ? 'text-income border-income/50 bg-income/10 hover:bg-income/20'
-                              : 'text-expense border-expense/50 bg-expense/10 hover:bg-expense/20'
-                          )}
+                          className="cursor-pointer transition-colors"
                           onClick={() => handleCategoryFilter(transaction.categoryId)}
+                          style={{ borderColor: getCategoryColor(transaction.categoryId) }}
                         >
                           {getCategoryName(transaction.categoryId)}
                         </Badge>
@@ -360,16 +359,16 @@ const TransactionsList = ({
                       </div>
                     </div>
                   </div>
-                  
-                   <div className="flex items-center gap-3">
-                     <span 
-                       className={`font-semibold transition-all duration-300 ${
-                         transaction.type === 'income' ? 'text-income' : 'text-expense'
-                       } ${!valuesVisible ? 'blur-md select-none' : ''}`}
-                     >
-                       {transaction.type === 'income' ? '+' : '-'}R$ {transaction.amount.toFixed(2).replace('.', ',')}
-                     </span>
-                    
+
+                  <div className="flex items-center justify-between sm:justify-end gap-3 w-full sm:w-auto">
+                    <span
+                      className={`font-semibold transition-all duration-300 ${
+                        transaction.type === 'income' ? 'text-income' : 'text-expense'
+                      } ${!valuesVisible ? 'blur-md select-none' : ''}`}
+                    >
+                      {transaction.type === 'income' ? '+' : '-'}R$ {transaction.amount.toFixed(2).replace('.', ',')}
+                    </span>
+
                     <div className="flex gap-1">
                       <Dialog>
                         <DialogTrigger asChild>

--- a/src/components/finance/UnifiedCharts.tsx
+++ b/src/components/finance/UnifiedCharts.tsx
@@ -164,6 +164,35 @@ const UnifiedCharts = ({
     );
   };
 
+  const renderCategoryTooltip = ({ active, payload, coordinate, viewBox }: TooltipProps<number, string> & { coordinate: { x: number; y: number }; viewBox: { cx: number; cy: number; outerRadius: number } }) => {
+    if (!active || !payload?.length) return null;
+    const { cx, cy, outerRadius } = viewBox;
+    const dx = coordinate.x - cx;
+    const dy = coordinate.y - cy;
+    const angle = Math.atan2(dy, dx);
+    const offset = 20;
+    const x = cx + Math.cos(angle) * (outerRadius + offset);
+    const y = cy + Math.sin(angle) * (outerRadius + offset);
+
+    return (
+      <div
+        className="px-2 py-1 rounded border text-xs space-y-1 pointer-events-none"
+        style={{
+          position: 'absolute',
+          left: x,
+          top: y,
+          backgroundColor: 'hsl(var(--card))',
+          borderColor: 'hsl(var(--border))',
+          color: 'hsl(var(--foreground))',
+          filter: valuesVisible ? 'none' : 'blur(4px)',
+        }}
+      >
+        <div>{payload[0].name}</div>
+        <div>{formatPercentage(Number(payload[0].value), totalExpense)}</div>
+      </div>
+    );
+  };
+
   const sixMonthData = generateSixMonthTrend();
   const { dailyData, dailyAverage, projectedTotal } = generateDailyProjection();
 
@@ -301,21 +330,7 @@ const UnifiedCharts = ({
                             />
                           ))}
                         </Pie>
-                        <Tooltip
-                          formatter={(value: number, _name, props) => [
-                            formatPercentage(Number(value), totalExpense),
-                            props?.payload?.name,
-                          ]}
-                          wrapperStyle={{ filter: valuesVisible ? 'none' : 'blur(4px)' }}
-                          contentStyle={{
-                            backgroundColor: 'hsl(var(--card))',
-                            border: '1px solid hsl(var(--border))',
-                            borderRadius: '6px',
-                            fontSize: '12px',
-                          }}
-                          itemStyle={{ color: 'hsl(var(--foreground))' }}
-                          labelStyle={{ color: 'hsl(var(--foreground))' }}
-                        />
+                        <Tooltip content={renderCategoryTooltip} position={{ x: 0, y: 0 }} />
                       </PieChart>
                     </ResponsiveContainer>
                     <div className="absolute inset-0 flex flex-col items-center justify-center text-xs pointer-events-none">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,9 @@
 
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
-import { CalendarIcon, ChevronLeft, ChevronRight, DollarSign, Lock } from "lucide-react";
+import { CalendarIcon, ChevronLeft, ChevronRight, DollarSign, Lock, Eye, EyeOff } from "lucide-react";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { cn } from "@/lib/utils";
@@ -22,6 +21,8 @@ interface HeaderProps {
   onUpdateCategory: (id: string, updates: Partial<Category>) => void;
   onDeleteCategory: (id: string) => void;
   onLock?: () => void;
+  valuesVisible: boolean;
+  onToggleValues: () => void;
 }
 
 const Header = ({ 
@@ -33,7 +34,9 @@ const Header = ({
   onAddCategory,
   onUpdateCategory,
   onDeleteCategory,
-  onLock
+  onLock,
+  valuesVisible,
+  onToggleValues
 }: HeaderProps) => {
   const currentDateObj = new Date(currentDate.year, currentDate.month - 1);
   const monthName = format(currentDateObj, "MMMM yyyy", { locale: ptBR });
@@ -65,6 +68,19 @@ const Header = ({
               <h1 className="text-base font-semibold text-foreground">Finanças</h1>
             </div>
             <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={onToggleValues}
+                className="h-7 w-7"
+                title={valuesVisible ? "Ocultar valores" : "Mostrar valores"}
+              >
+                {valuesVisible ? (
+                  <EyeOff className="w-3.5 h-3.5" />
+                ) : (
+                  <Eye className="w-3.5 h-3.5" />
+                )}
+              </Button>
               <Button
                 variant="outline"
                 size="icon"
@@ -191,7 +207,7 @@ const Header = ({
 
           {/* Actions */}
           <div className="flex items-center gap-2">
-            <AddTransactionDialog 
+            <AddTransactionDialog
               categories={categories}
               onAddTransaction={onAddTransaction}
               onAddCategory={onAddCategory}
@@ -204,6 +220,15 @@ const Header = ({
               onUpdateCategory={onUpdateCategory}
               onDeleteCategory={onDeleteCategory}
             />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={onToggleValues}
+              className="h-9 w-9"
+              title={valuesVisible ? "Ocultar valores" : "Mostrar valores"}
+            >
+              {valuesVisible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </Button>
             <Button
               variant="outline"
               size="icon"

--- a/src/pages/FinanceDashboard.tsx
+++ b/src/pages/FinanceDashboard.tsx
@@ -16,6 +16,7 @@ import { Plus } from "lucide-react";
 const FinanceDashboard = () => {
   const [isUnlocked, setIsUnlocked] = useState(false);
   const [activeTab, setActiveTab] = useState<'summary' | 'transactions' | 'charts'>('summary');
+  const [valuesVisible, setValuesVisible] = useState(false);
   
   const {
     categories,
@@ -54,6 +55,17 @@ const FinanceDashboard = () => {
     sessionStorage.removeItem('finance-unlocked');
   };
 
+  const toggleValuesVisibility = () => {
+    setValuesVisible((prev) => !prev);
+  };
+
+  useEffect(() => {
+    if (valuesVisible) {
+      const timer = setTimeout(() => setValuesVisible(false), 5 * 60 * 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [valuesVisible]);
+
   if (!isUnlocked) {
     return (
       <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
@@ -77,12 +89,14 @@ const FinanceDashboard = () => {
           onUpdateCategory={updateCategory}
           onDeleteCategory={deleteCategory}
           onLock={handleLock}
+          valuesVisible={valuesVisible}
+          onToggleValues={toggleValuesVisibility}
         />
         
         <main className="container mx-auto px-2 sm:px-4 py-4 sm:py-6 space-y-4 sm:space-y-6">
           {/* Desktop Layout */}
           <div className="hidden sm:block space-y-4 sm:space-y-6">
-            <FinancialSummary monthlyData={currentMonthData} />
+            <FinancialSummary monthlyData={currentMonthData} valuesVisible={valuesVisible} />
             
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
               {/* Left Column - Transactions List */}
@@ -118,7 +132,7 @@ const FinanceDashboard = () => {
             {/* Tab Content */}
             {activeTab === 'summary' && (
               <div className="space-y-4">
-                <FinancialSummary monthlyData={currentMonthData} />
+                <FinancialSummary monthlyData={currentMonthData} valuesVisible={valuesVisible} />
               </div>
             )}
             


### PR DESCRIPTION
## Summary
- move value-visibility toggle to header with compact eye icon
- add custom pie chart tooltip positioned outside the donut
- refine transaction list for mobile and align category colors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a21a41f408832abb27f44cc0a2b743