### PR TITLE
refactor: tighten transactions card layout

### DIFF
--- a/src/components/finance/TransactionsList.tsx
+++ b/src/components/finance/TransactionsList.tsx
@@ -186,8 +186,8 @@ const TransactionsList = ({
     .filter(Boolean) as Category[];
 
   return (
-    <Card className="flex flex-col h-fit">
-      <Tabs value={activeTab} onValueChange={setActiveTab} defaultValue="list" className="flex flex-col">
+    <Card className="flex flex-col h-full">
+      <Tabs value={activeTab} onValueChange={setActiveTab} defaultValue="list" className="flex flex-col h-full">
         <CardHeader>
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
             <div className="flex-1">
@@ -206,7 +206,7 @@ const TransactionsList = ({
           </div>
         </CardHeader>
 
-        <TabsContent value="list" className="flex flex-col mt-0 px-4 sm:px-6 pb-4 sm:pb-6 pt-2">
+        <TabsContent value="list" className="flex flex-col flex-1 mt-0 px-4 sm:px-6 pb-2 sm:pb-4 pt-2">
           <div className="flex justify-end mb-4">
             <Select
               value={sortOrder}
@@ -341,17 +341,17 @@ const TransactionsList = ({
           )}
 
           {sortedTransactions.length === 0 && !showBalancePrompt ? (
-            <div className="flex items-center justify-center h-48">
+            <div className="flex items-center justify-center flex-1">
                 <p className="text-muted-foreground text-center">
                     Nenhuma transação encontrada para este mês.
                 </p>
             </div>
           ) : (
-            <div>
+            <div className="flex flex-col flex-1">
               {/* Lista de Transações */}
               <div
                 className={cn(
-                  "space-y-3 sm:space-y-4 transition-all duration-300 ease-in-out",
+                  "space-y-3 sm:space-y-4 transition-all duration-300 ease-in-out flex-1",
                   isAnimating && "opacity-75 scale-[0.99]"
                 )}
               >
@@ -554,13 +554,13 @@ const TransactionsList = ({
 
               {/* Controles de expansão minimalistas */}
               {(hasMore || showAll) && (
-                <div className="mt-6">
+                <div className="mt-4">
                   {/* Gradient fade effect */}
                   {hasMore && !showAll && (
-                    <div className="h-6 bg-gradient-to-t from-card to-transparent -mb-2 relative z-10" />
+                    <div className="h-4 bg-gradient-to-t from-card to-transparent -mb-1 relative z-10" />
                   )}
-                  
-                  <div className="flex justify-center pt-4 pb-2">
+
+                  <div className="flex justify-center pt-2 pb-0">
                     {showAll ? (
                       <Button
                         variant="ghost"

--- a/src/pages/FinanceDashboard.tsx
+++ b/src/pages/FinanceDashboard.tsx
@@ -101,7 +101,7 @@ const FinanceDashboard = () => {
           <div className="hidden sm:block space-y-4 sm:space-y-6">
             <FinancialSummary monthlyData={currentMonthData} valuesVisible={valuesVisible} />
             
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 lg:items-start">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 lg:items-stretch">
               {/* Left Column - Transactions List */}
               <TransactionsList
                 transactions={currentMonthData.transactions}


### PR DESCRIPTION
## Summary
- stretch transactions card to match neighbor height
- trim excess spacing and refine collapse controls
- stretch dashboard grid items for balanced columns

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3c4a34ca4832a9b623c9f1c1af838