### PR TITLE
feat: collapse overflowing filter tags

### DIFF
--- a/src/pages/FinanceDashboard.tsx
+++ b/src/pages/FinanceDashboard.tsx
@@ -101,7 +101,7 @@ const FinanceDashboard = () => {
           <div className="hidden sm:block space-y-4 sm:space-y-6">
             <FinancialSummary monthlyData={currentMonthData} valuesVisible={valuesVisible} />
             
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 lg:items-start">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 lg:items-stretch">
               {/* Left Column - Transactions List */}
               <TransactionsList
                 transactions={currentMonthData.transactions}


### PR DESCRIPTION
## Summary
- stretch transactions card to match neighbor height
- trim excess spacing and refine collapse controls
- stretch dashboard grid items for balanced columns
- clamp transaction filter tags to a single row with expandable overflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3c4a34ca4832a9b623c9f1c1af838